### PR TITLE
Floor final font size

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,7 @@ function optimalFontSize(wordRatios: number[], maxWidth: number, maxHeight: numb
       high = fontSize;
     }
   }
-  return low;
+  return Math.floor(low);
 }
 
 function checkConstraints(fontSize: number, wordRatios: number[], maxWidth: number, maxHeight: number, lineHeightRatio: number) {


### PR DESCRIPTION
Flooring the final font size so the browser doesn't round it up breaking the text out of the container.

See issue: #1 