### PR TITLE
Prevent invisible element from occupying any space

### DIFF
--- a/src/helpers/lineHeight.ts
+++ b/src/helpers/lineHeight.ts
@@ -1,5 +1,8 @@
 import { lru_cached } from '../lru';
 let invisibleElement = document.createElement('div');
+invisibleElement.style.position = 'absolute';
+invisibleElement.style.top = '0px';
+invisibleElement.style.left = '0px';
 invisibleElement.style.visibility = 'hidden';
 invisibleElement.style.height = 'auto';
 invisibleElement.style.width = 'auto';


### PR DESCRIPTION
1) The invisible element still occupies a bit of space at the bottom of the page.
2) `z-index` makes no sense as the element's position is `static`.

This PR fixes both by providing the element with an `absolute` position.